### PR TITLE
Add support for persisting ProtectedStoragePayload used for ProposalPayload

### DIFF
--- a/src/main/java/bisq/monitor/metrics/p2p/MonitorRequestHandler.java
+++ b/src/main/java/bisq/monitor/metrics/p2p/MonitorRequestHandler.java
@@ -112,7 +112,7 @@ class MonitorRequestHandler implements MessageListener {
         peersNodeAddress = nodeAddress;
         requestTs = new Date().getTime();
         if (!stopped) {
-            Set<byte[]> excludedKeys = dataStorage.getPersistableNetworkPayloadCollection().getMap().entrySet().stream()
+            Set<byte[]> excludedKeys = dataStorage.getPersistableNetworkPayloadList().getMap().entrySet().stream()
                     .map(e -> e.getKey().bytes)
                     .collect(Collectors.toSet());
 


### PR DESCRIPTION
- Add ProposalPayload interface to ProposalPayload
- Add protectedStoragePayload to persistedEntryMap if payload is an instance of PersistablePayload
- Remove protectedStoragePayload from persistedEntryMap if payload is an instance of PersistablePayload
- Rename PersistableNetworkPayloadCollection to PersistableNetworkPayloadList to be in sync with PB definition
- Replace stream().forEach by forEach
- Refactor readFromResources method to pass file name and prost fix separate